### PR TITLE
Fixes for compiliation on Windows (take 2)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "xz-embedded-sys/xz-embedded"]
 	path = xz-embedded-sys/xz-embedded
-	url = http://git.tukaani.org/xz-embedded.git
+	url = https://github.com/XZliblzma/xz-embedded.git

--- a/xz-embedded-sys/Cargo.toml
+++ b/xz-embedded-sys/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 libc = "0.1"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 [lib]
 name = "xz_embedded_sys"

--- a/xz-embedded-sys/build.rs
+++ b/xz-embedded-sys/build.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+extern crate cc;
 
 use std::path::Path;
 
@@ -8,7 +8,7 @@ fn main() {
     let src_dir = Path::new("xz-embedded/linux/lib/xz/");
     let inc_dir = Path::new("xz-embedded/linux/include/linux");
 
-    let mut cfg = gcc::Config::new();
+    let mut cfg = cc::Build::new();
 
     for file in files {
         cfg.file(src_dir.join(file));
@@ -18,12 +18,16 @@ fn main() {
 
     cfg.define("XZ_USE_CRC64", None)
        .define("XZ_DEC_ANY_CHECK", None)
-       .flag("-std=gnu89")
-       .flag("-ggdb3")
-       .flag("-pedantic")
-       .flag("-Wall")
-       .flag("-Wextra")
        .opt_level(2);
+    
+    #[cfg(not(windows))]
+    {
+        cfg.flag("-std=gnu89")
+           .flag("-ggdb3")
+           .flag("-pedantic")
+           .flag("-Wall")
+           .flag("-Wextra");
+    }
 
     cfg.compile("libxzembedded.a");
 


### PR DESCRIPTION
Fixed version of https://github.com/eminence/xz-decom/pull/2 - fixed up the submodule. Sorry about that!

----

Hi!

This PR fixes the upstream submodule used by this library (which has intermittent connection issues) and points it to Github. Furthermore, this uses a modern cc build dependency, and fixes build flags on Windows platforms.

Feedback would be great!